### PR TITLE
[Fork] Fix warning vite missing exports condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "main": "dist/svelte-infinite-loading.js",
   "module": "dist/svelte-infinite-loading.mjs",
   "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "svelte": "./src/index.js"
+    }
+  },
   "scripts": {
     "build": "rollup -c",
     "lint": "eslint src/** test/**",


### PR DESCRIPTION
I don't think this is needed after migrating to the SvelteKit library template, but I'll leave this here for reference.